### PR TITLE
Update the install script for doppler to avoid apt-key

### DIFF
--- a/src/doppler/install.sh
+++ b/src/doppler/install.sh
@@ -12,31 +12,29 @@ echo "doppler completion files installed: $COMPLETION"
 DIRECTORY="$_REMOTE_USER_HOME"
 
 export DEBIAN_FRONTEND=noninteractive
-apt_get_update()
-{
-    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
-        echo "Running apt-get update..."
-        apt-get update -y
-    fi
+apt_get_update() {
+  if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+    echo "Running apt-get update..."
+    apt-get update -y
+  fi
 }
 
 # Checks if packages are installed and installs them if not
 check_packages() {
-    if ! dpkg -s "$@" > /dev/null 2>&1; then
-        apt_get_update
-        apt-get -y install --no-install-recommends "$@"
-    fi
+  if ! dpkg -s "$@" >/dev/null 2>&1; then
+    apt_get_update
+    apt-get -y install --no-install-recommends "$@"
+  fi
 }
 
 apt_get_update
 check_packages apt-transport-https ca-certificates curl gnupg
 
-
-# Add Doppler's GPG key
-curl -sLf --retry 3 --tlsv1.2 --proto "=https" 'https://packages.doppler.com/public/cli/gpg.DE2A7741A397C129.key' | apt-key add -
+# Add Doppler's GPG key without apt-key (deprecated)
+curl -sLf --retry 3 --tlsv1.2 --proto "=https" 'https://packages.doppler.com/public/cli/gpg.DE2A7741A397C129.key' | sudo gpg --dearmor -o /usr/share/keyrings/doppler-archive-keyring.gpg
 
 # Add Doppler's apt repo
-echo "deb https://packages.doppler.com/public/cli/deb/debian any-version main" > /etc/apt/sources.list.d/doppler-cli.list
+echo "deb [signed-by=/usr/share/keyrings/doppler-archive-keyring.gpg] https://packages.doppler.com/public/cli/deb/debian any-version main" | sudo tee /etc/apt/sources.list.d/doppler-cli.list
 
 # Fetch and install latest doppler cli
 apt-get update && apt-get install -y doppler
@@ -46,18 +44,18 @@ cp ${PWD}/scripts/setup-doppler.sh /usr/local/share/doppler/setup-doppler.sh
 chmod +x /usr/local/share/doppler/setup-doppler.sh
 
 if [ "$COMPLETION" = "true" ]; then
-    apt-get install -y bash-completion
+  apt-get install -y bash-completion
 
-    mkdir -p /usr/share/bash-completion/completions
-    doppler completion install bash
+  mkdir -p /usr/share/bash-completion/completions
+  doppler completion install bash
 
-    mkdir -p /usr/local/share/zsh/site-functions
-    doppler completion install zsh
+  mkdir -p /usr/local/share/zsh/site-functions
+  doppler completion install zsh
 
-    # for some reason you can't install fish completions from a shell
-    # other than fish. So we'll skip until someone files an issue.
-    #mkdir -p /usr/share/fish/vendor_completions.d
-    #doppler completion install fish
+  # for some reason you can't install fish completions from a shell
+  # other than fish. So we'll skip until someone files an issue.
+  #mkdir -p /usr/share/fish/vendor_completions.d
+  #doppler completion install fish
 fi
 
 # Clean up


### PR DESCRIPTION
I've updated the install script to avoid a call to apt-key as this was causing errors when building:

```
1.605 Reading package lists...
1.842 W: https://dl.yarnpkg.com/debian/dists/stable/InRelease: Policy will
reject signature within a year, see --audit for details
1.844 ./install.sh: 36: apt-key: not found
1.949 ERROR: Feature "doppler CLI"
(ghcr.io/metcalfc/devcontainer-features/doppler) failed to install!
```

The specs for atuin and dagger are both failing, but this isn't related to this PR as far as I can tell.