### PR TITLE
Refactor Dagger installation and update Atuin dependencies

### DIFF
--- a/src/atuin/scripts/bash-preexec.sh
+++ b/src/atuin/scripts/bash-preexec.sh
@@ -9,7 +9,7 @@
 # Author: Ryan Caloras (ryan@bashhub.com)
 # Forked from Original Author: Glyph Lefkowitz
 #
-# V0.5.0
+# V0.6.0
 #
 
 # General Usage:
@@ -38,7 +38,7 @@
 # Make sure this is bash that's running and return otherwise.
 # Use POSIX syntax for this line:
 if [ -z "${BASH_VERSION-}" ]; then
-    return 1;
+    return 1
 fi
 
 # We only support Bash 3.1+.
@@ -48,7 +48,7 @@ if [[ -z "${BASH_VERSINFO-}" ]] || (( BASH_VERSINFO[0] < 3 || (BASH_VERSINFO[0] 
 fi
 
 # Avoid duplicate inclusion
-if [[ -n "${bash_preexec_imported:-}" ]]; then
+if [[ -n "${bash_preexec_imported:-}" || -n "${__bp_imported:-}" ]]; then
     return 0
 fi
 bash_preexec_imported="defined"
@@ -76,13 +76,13 @@ __bp_install_string=$'__bp_trap_string="$(trap -p DEBUG)"\ntrap - DEBUG\n__bp_in
 # Fails if any of the given variables are readonly
 # Reference https://stackoverflow.com/a/4441178
 __bp_require_not_readonly() {
-  local var
-  for var; do
-    if ! ( unset "$var" 2> /dev/null ); then
-      echo "bash-preexec requires write access to ${var}" >&2
-      return 1
-    fi
-  done
+    local var
+    for var; do
+        if ! ( unset "$var" 2> /dev/null ); then
+            echo "bash-preexec requires write access to ${var}" >&2
+            return 1
+        fi
+    done
 }
 
 # Remove ignorespace and or replace ignoreboth from HISTCONTROL
@@ -95,7 +95,7 @@ __bp_adjust_histcontrol() {
     # Replace ignoreboth with ignoredups
     if [[ "$histcontrol" == *"ignoreboth"* ]]; then
         histcontrol="ignoredups:${histcontrol//ignoreboth}"
-    fi;
+    fi
     export HISTCONTROL="$histcontrol"
 }
 
@@ -136,7 +136,7 @@ __bp_sanitize_string() {
 # It sets a variable to indicate that the prompt was just displayed,
 # to allow the DEBUG trap to know that the next command is likely interactive.
 __bp_interactive_mode() {
-    __bp_preexec_interactive_mode="on";
+    __bp_preexec_interactive_mode="on"
 }
 
 
@@ -154,7 +154,7 @@ __bp_precmd_invoke_cmd() {
     # prompt command" by another precmd execution loop. This avoids infinite
     # recursion.
     if (( __bp_inside_precmd > 0 )); then
-      return
+        return
     fi
     local __bp_inside_precmd=1
 
@@ -211,7 +211,7 @@ __bp_preexec_invoke_exec() {
     __bp_last_argument_prev_command="${1:-}"
     # Don't invoke preexecs if we are inside of another preexec.
     if (( __bp_inside_preexec > 0 )); then
-      return
+        return
     fi
     local __bp_inside_preexec=1
 
@@ -222,9 +222,9 @@ __bp_preexec_invoke_exec() {
         return
     fi
 
-    if [[ -n "${COMP_LINE:-}" ]]; then
-        # We're in the middle of a completer. This obviously can't be
-        # an interactively issued command.
+    if [[ -n "${COMP_POINT:-}" || -n "${READLINE_POINT:-}" ]]; then
+        # We're in the middle of a completer or a keybinding set up by "bind
+        # -x".  This obviously can't be an interactively issued command.
         return
     fi
     if [[ -z "${__bp_preexec_interactive_mode:-}" ]]; then
@@ -250,10 +250,8 @@ __bp_preexec_invoke_exec() {
     fi
 
     local this_command
-    this_command=$(
-        export LC_ALL=C
-        HISTTIMEFORMAT='' builtin history 1 | sed '1 s/^ *[0-9][0-9]*[* ] //'
-    )
+    this_command=$(LC_ALL=C HISTTIMEFORMAT='' builtin history 1)
+    this_command="${this_command#*[[:digit:]][* ] }"
 
     # Sanity check to make sure we have something to invoke our function with.
     if [[ -z "$this_command" ]]; then
@@ -291,20 +289,18 @@ __bp_preexec_invoke_exec() {
 __bp_install() {
     # Exit if we already have this installed.
     if [[ "${PROMPT_COMMAND[*]:-}" == *"__bp_precmd_invoke_cmd"* ]]; then
-        return 1;
+        return 1
     fi
 
     trap '__bp_preexec_invoke_exec "$_"' DEBUG
 
     # Preserve any prior DEBUG trap as a preexec function
-    local prior_trap
-    # we can't easily do this with variable expansion. Leaving as sed command.
-    # shellcheck disable=SC2001
-    prior_trap=$(sed "s/[^']*'\(.*\)'[^']*/\1/" <<<"${__bp_trap_string:-}")
+    eval "local trap_argv=(${__bp_trap_string:-})"
+    local prior_trap=${trap_argv[2]:-}
     unset __bp_trap_string
     if [[ -n "$prior_trap" ]]; then
         eval '__bp_original_debug_trap() {
-          '"$prior_trap"'
+            '"$prior_trap"'
         }'
         preexec_functions+=(__bp_original_debug_trap)
     fi
@@ -321,7 +317,7 @@ __bp_install() {
         # Set so debug trap will work be invoked in subshells.
         set -o functrace > /dev/null 2>&1
         shopt -s extdebug > /dev/null 2>&1
-    fi;
+    fi
 
     local existing_prompt_command
     # Remove setting our trap install string and sanitize the existing prompt command string
@@ -369,7 +365,7 @@ __bp_install_after_session_init() {
     if [[ -n "$sanitized_prompt_command" ]]; then
         # shellcheck disable=SC2178 # PROMPT_COMMAND is not an array in bash <= 5.0
         PROMPT_COMMAND=${sanitized_prompt_command}$'\n'
-    fi;
+    fi
     # shellcheck disable=SC2179 # PROMPT_COMMAND is not an array in bash <= 5.0
     PROMPT_COMMAND+=${__bp_install_string}
 }
@@ -377,4 +373,4 @@ __bp_install_after_session_init() {
 # Run our install so long as we're not delaying it.
 if [[ -z "${__bp_delay_install:-}" ]]; then
     __bp_install_after_session_init
-fi;
+fi

--- a/src/atuin/scripts/install-atuin.sh
+++ b/src/atuin/scripts/install-atuin.sh
@@ -1,6 +1,5 @@
-#! /usr/bin/env bash
-
-set -euo pipefail
+#! /bin/sh
+set -eu
 
 cat << EOF
  _______  _______  __   __  ___   __    _
@@ -15,173 +14,34 @@ Magical shell history
 
 Atuin setup
 https://github.com/atuinsh/atuin
+https://forum.atuin.sh
 
-Please file an issue if you encounter any problems!
+Please file an issue or reach out on the forum if you encounter any problems!
 
 ===============================================================================
 
 EOF
 
-if ! command -v curl &> /dev/null; then
+__atuin_install_binary(){
+  curl --proto '=https' --tlsv1.2 -LsSf https://github.com/atuinsh/atuin/releases/latest/download/atuin-installer.sh | sh
+}
+
+if ! command -v curl > /dev/null; then
     echo "curl not installed. Please install curl."
     exit
-elif ! command -v sed &> /dev/null; then
+elif ! command -v sed > /dev/null; then
     echo "sed not installed. Please install sed."
     exit
 fi
 
-LATEST_RELEASE=$(curl -L -s -H 'Accept: application/json' https://github.com/atuinsh/atuin/releases/latest)
-# Allow sed; sometimes it's more readable than ${variable//search/replace}
-# shellcheck disable=SC2001
-LATEST_VERSION=$(echo "$LATEST_RELEASE" | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
 
-__atuin_install_arch(){
-	echo "Arch Linux detected!"
-
-	if command -v pacman &> /dev/null
-	then
-		echo "Installing with pacman"
-		sudo pacman -S atuin
-	else
-		echo "Attempting AUR install"
-		if command -v yaourt &> /dev/null; then
-			echo "Found yaourt"
-			yaourt -S atuin
-		elif command -v yay &> /dev/null; then
-			echo "Found yay"
-			yay -S atuin
-		elif command -v pakku &> /dev/null; then
-			echo "Found pakku"
-			pakku -S atuin
-		elif command -v pamac &> /dev/null; then
-			echo "Found pamac"
-			pamac install atuin
-		else
-			echo "Failed to install atuin! Please try manually: https://aur.archlinux.org/packages/atuin-git/"
-		fi
-	fi
-
-}
-
-__atuin_install_ubuntu(){
-	if [ "$(dpkg --print-architecture)" = "amd64" ]; then
-		echo "Ubuntu detected"
-		ARTIFACT_URL="https://github.com/atuinsh/atuin/releases/download/$LATEST_VERSION/atuin_${LATEST_VERSION//v/}_amd64.deb"
-		TEMP_DEB="$(mktemp)".deb &&
-		curl -Lo "$TEMP_DEB" "$ARTIFACT_URL"
-		if command -v sudo &> /dev/null; then
-			sudo apt install "$TEMP_DEB"
-		else
-			su -l -c "apt install '$TEMP_DEB'"
-		fi
-		rm -f "$TEMP_DEB"
-	else
-		echo "Ubuntu detected, but not amd64"
-		__atuin_install_unsupported
-	fi
-}
-
-__atuin_install_linux(){
-	echo "Detected Linux!"
-	echo "Checking distro..."
-	if (uname -a | grep -qi "Microsoft"); then
-    OS="ubuntuwsl"
-  elif ! command -v lsb_release &> /dev/null; then
-    echo "lsb_release could not be found. Falling back to /etc/os-release"
-    OS="$(grep -Po '(?<=^ID=).*$' /etc/os-release | tr '[:upper:]' '[:lower:]')" 2>/dev/null
-  else
-    OS=$(lsb_release -i | awk '{ print $3 }' | tr '[:upper:]' '[:lower:]')
-  fi
-	case "$OS" in
-		"arch" | "manjarolinux" | "endeavouros")
-			__atuin_install_arch;;
-		"ubuntu" | "ubuntuwsl" | "debian" | "linuxmint" | "parrot" | "kali" | "elementary" | "pop")
-			__atuin_install_ubuntu;;
-		*)
-			# TODO: download a binary or smth
-			__atuin_install_unsupported;;
-	esac
-}
-
-__atuin_install_mac(){
-	echo "Detected Mac!"
-
-	if command -v brew &> /dev/null
-	then
-		echo "Installing with brew"
-		brew install atuin
-	else
-		echo "Could not find brew, installing with Cargo"
-		__atuin_install_unsupported
-	fi
-
-}
-
-__atuin_install_termux(){
-	echo "Termux detected!"
-
-	if command -v pkg &> /dev/null; then
-		echo "Installing with pkg"
-		pkg install atuin
-	else
-		echo "Could not find pkg"
-		__atuin_install_unsupported
-	fi
-}
-
-__atuin_install_cargo(){
-	echo "Attempting install with cargo"
-
-	if ! command -v cargo &> /dev/null
-	then
-		echo "cargo not found! Attempting to install rustup"
-
-		if command -v rustup &> /dev/null
-		then
-			echo "rustup was found, but cargo wasn't. Something is up with your install"
-			exit 1
-		fi
-
-		curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -q
-
-		echo "rustup installed! Attempting cargo install"
-
-	fi
-
-	cargo install atuin
-}
-
-__atuin_install_unsupported(){
-	echo "Unknown or unsupported OS or architecture"
-	echo "Please check the README at https://github.com/atuinsh/atuin for manual install instructions"
-	echo "If you have any problems, please open an issue!"
-
-	while true; do
-		read -r -p "Do you wish to attempt an install with 'cargo'? [Y/N] " yn
-		case $yn in
-			[Yy]* ) __atuin_install_cargo; break;;
-			[Nn]* ) exit;;
-			* ) echo "Please answer yes or no.";;
-		esac
-	done
-}
-
-# TODO: would be great to support others!
-case "$OSTYPE" in
-  linux-android*) __atuin_install_termux ;;
-  linux*)         __atuin_install_linux ;;
-  darwin*)        __atuin_install_mac ;;
-  msys*)          __atuin_install_unsupported ;;
-  solaris*)       __atuin_install_unsupported ;;
-  bsd*)           __atuin_install_unsupported ;;
-  *)              __atuin_install_unsupported ;;
-esac
+__atuin_install_binary 
 
 # TODO: Check which shell is in use
 # Use of single quotes around $() is intentional here
 # shellcheck disable=SC2016
-if ! grep -q "atuin init zsh" ~/.zshrc; then
-  printf '\neval "$(atuin init zsh)"\n' >> ~/.zshrc
+if ! grep -q "atuin init zsh" "${ZDOTDIR:-$HOME}/.zshrc"; then
+  printf '\neval "$(atuin init zsh)"\n' >> "${ZDOTDIR:-$HOME}/.zshrc"
 fi
 
 # Use of single quotes around $() is intentional here
@@ -191,6 +51,22 @@ if ! grep -q "atuin init bash" ~/.bashrc; then
   curl https://raw.githubusercontent.com/rcaloras/bash-preexec/master/bash-preexec.sh -o ~/.bash-preexec.sh
   printf '\n[[ -f ~/.bash-preexec.sh ]] && source ~/.bash-preexec.sh\n' >> ~/.bashrc
   echo 'eval "$(atuin init bash)"' >> ~/.bashrc
+fi
+
+if [ -f "$HOME/.config/fish/config.fish" ]; then
+  # Check if the line already exists to prevent duplicates
+  if ! grep -q "atuin init fish" "$HOME/.config/fish/config.fish"; then
+        # Detect BSD or GNU sed
+        if sed --version >/dev/null 2>&1; then
+          # GNU
+          sed -i '/if status is-interactive/,/end/ s/end$/    atuin init fish | source\
+end/' "$HOME/.config/fish/config.fish"
+        else
+          # BSD (macOS)
+          sed -i '' '/if status is-interactive/,/end/ s/end$/    atuin init fish | source\
+end/' "$HOME/.config/fish/config.fish"
+        fi
+    fi
 fi
 
 cat << EOF
@@ -209,7 +85,7 @@ cat << EOF
 
 Thanks for installing Atuin! I really hope you like it.
 
-If you have any issues, please open an issue on GitHub or visit our Discord (https://discord.gg/dPhv2B3x)!
+If you have any issues, please open an issue on GitHub or visit our forum (https://forum.atuin.sh)!
 
 If you love Atuin, please give us a star on GitHub! It really helps ⭐️ https://github.com/atuinsh/atuin
 

--- a/src/dagger/install-dagger.sh
+++ b/src/dagger/install-dagger.sh
@@ -1,0 +1,380 @@
+#!/bin/sh
+
+set -e
+
+name="dagger"
+base="https://dl.dagger.io"
+
+cat /dev/null <<EOF
+------------------------------------------------------------------------
+https://github.com/client9/shlib - portable posix shell functions
+Public domain - http://unlicense.org
+https://github.com/client9/shlib/blob/master/LICENSE.md
+but credit (and pull requests) appreciated.
+------------------------------------------------------------------------
+EOF
+is_command() {
+  command -v "$1" >/dev/null
+}
+echoerr() {
+  echo "$@" 1>&2
+}
+log_prefix() {
+  echo "$0"
+}
+_logp=7
+log_set_priority() {
+  _logp="$1"
+}
+log_priority() {
+  if test -z "$1"; then
+    echo "$_logp"
+    return
+  fi
+  [ "$1" -le "$_logp" ]
+}
+log_tag() {
+  case $1 in
+    0) echo "emerg" ;;
+    1) echo "alert" ;;
+    2) echo "crit" ;;
+    3) echo "err" ;;
+    4) echo "warning" ;;
+    5) echo "notice" ;;
+    6) echo "info" ;;
+    7) echo "debug" ;;
+    *) echo "$1" ;;
+  esac
+}
+log_debug() {
+  log_priority 7 || return 0
+  echoerr "$(log_prefix)" "$(log_tag 7)" "$@"
+}
+log_info() {
+  log_priority 6 || return 0
+  echoerr "$(log_prefix)" "$(log_tag 6)" "$@"
+}
+log_err() {
+  log_priority 3 || return 0
+  echoerr "$(log_prefix)" "$(log_tag 3)" "$@"
+}
+log_crit() {
+  log_priority 2 || return 0
+  echoerr "$(log_prefix)" "$(log_tag 2)" "$@"
+}
+uname_os() {
+  os=$(uname -s | tr '[:upper:]' '[:lower:]')
+  case "$os" in
+    cygwin_nt*) os="windows" ;;
+    mingw*) os="windows" ;;
+    msys_nt*) os="windows" ;;
+  esac
+  echo "$os"
+}
+uname_arch() {
+  arch=$(uname -m)
+  case $arch in
+    x86_64) arch="amd64" ;;
+    x86) arch="386" ;;
+    i686) arch="386" ;;
+    i386) arch="386" ;;
+    aarch64) arch="arm64" ;;
+    armv5*) arch="armv5" ;;
+    armv6*) arch="armv6" ;;
+    armv7*) arch="armv7" ;;
+  esac
+  echo "${arch}"
+}
+uname_os_check() {
+  os=$(uname_os)
+  case "$os" in
+    darwin) return 0 ;;
+    dragonfly) return 0 ;;
+    freebsd) return 0 ;;
+    linux) return 0 ;;
+    android) return 0 ;;
+    nacl) return 0 ;;
+    netbsd) return 0 ;;
+    openbsd) return 0 ;;
+    plan9) return 0 ;;
+    solaris) return 0 ;;
+    windows) return 0 ;;
+  esac
+  log_crit "uname_os_check '$(uname -s)' got converted to '$os' which is not a GOOS value. Please file bug at https://github.com/client9/shlib"
+  return 1
+}
+uname_arch_check() {
+  arch=$(uname_arch)
+  case "$arch" in
+    386) return 0 ;;
+    amd64) return 0 ;;
+    arm64) return 0 ;;
+    armv5) return 0 ;;
+    armv6) return 0 ;;
+    armv7) return 0 ;;
+    ppc64) return 0 ;;
+    ppc64le) return 0 ;;
+    mips) return 0 ;;
+    mipsle) return 0 ;;
+    mips64) return 0 ;;
+    mips64le) return 0 ;;
+    s390x) return 0 ;;
+    amd64p32) return 0 ;;
+  esac
+  log_crit "uname_arch_check '$(uname -m)' got converted to '$arch' which is not a GOARCH value.  Please file bug report at https://github.com/client9/shlib"
+  return 1
+}
+untar() {
+  tarball=$1
+  case "${tarball}" in
+    *.tar.gz | *.tgz) tar --no-same-owner -xzf "${tarball}" ;;
+    *.tar) tar --no-same-owner -xf "${tarball}" ;;
+    *.zip) unzip "${tarball}" ;;
+    *)
+      log_err "untar unknown archive format for ${tarball}"
+      return 1
+      ;;
+  esac
+}
+http_download_curl() {
+  local_file=$1
+  source_url=$2
+  header=$3
+  if [ -z "$header" ]; then
+    code=$(curl -w '%{http_code}' -sL -o "$local_file" "$source_url")
+  else
+    code=$(curl -w '%{http_code}' -sL -H "$header" -o "$local_file" "$source_url")
+  fi
+  if [ "$code" != "200" ]; then
+    log_debug "http_download_curl received HTTP status $code"
+    return 1
+  fi
+  return 0
+}
+http_download_wget() {
+  local_file=$1
+  source_url=$2
+  header=$3
+  if [ -z "$header" ]; then
+    wget -q -O "$local_file" "$source_url"
+  else
+    wget -q --header "$header" -O "$local_file" "$source_url"
+  fi
+}
+http_download() {
+  log_debug "http_download $2"
+  if is_command curl; then
+    http_download_curl "$@"
+    return
+  elif is_command wget; then
+    http_download_wget "$@"
+    return
+  fi
+  log_crit "http_download unable to find wget or curl"
+  return 1
+}
+http_copy() {
+  tmp=$(mktemp)
+  http_download "${tmp}" "$1" "$2" || return 1
+  body=$(cat "$tmp")
+  rm -f "${tmp}"
+  echo "$body"
+}
+github_release() {
+  owner_repo=$1
+  version=$2
+  test -z "$version" && version="latest"
+  giturl="https://github.com/${owner_repo}/releases/${version}"
+  json=$(http_copy "$giturl" "Accept:application/json")
+  test -z "$json" && return 1
+  version=$(echo "$json" | tr -s '\n' ' ' | sed 's/.*"tag_name":"//' | sed 's/".*//')
+  test -z "$version" && return 1
+  echo "$version"
+}
+hash_sha256() {
+  TARGET=${1:-/dev/stdin}
+  if is_command gsha256sum; then
+    hash=$(gsha256sum "$TARGET") || return 1
+    echo "$hash" | cut -d ' ' -f 1
+  elif is_command sha256sum; then
+    hash=$(sha256sum "$TARGET") || return 1
+    echo "$hash" | cut -d ' ' -f 1
+  elif is_command shasum; then
+    hash=$(shasum -a 256 "$TARGET" 2>/dev/null) || return 1
+    echo "$hash" | cut -d ' ' -f 1
+  elif is_command openssl; then
+    hash=$(openssl -dst openssl dgst -sha256 "$TARGET") || return 1
+    echo "$hash" | cut -d ' ' -f a
+  else
+    log_crit "hash_sha256 unable to find command to compute sha-256 hash"
+    return 1
+  fi
+}
+hash_sha256_verify() {
+  TARGET=$1
+  checksums=$2
+  if [ -z "$checksums" ]; then
+    log_err "hash_sha256_verify checksum file not specified in arg2"
+    return 1
+  fi
+  BASENAME=${TARGET##*/}
+  want=$(grep "${BASENAME}" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)
+  if [ -z "$want" ]; then
+    log_err "hash_sha256_verify unable to find checksum for '${TARGET}' in '${checksums}'"
+    return 1
+  fi
+  got=$(hash_sha256 "$TARGET")
+  if [ "$want" != "$got" ]; then
+    log_err "hash_sha256_verify checksum for '$TARGET' did not verify ${want} vs $got"
+    return 1
+  fi
+}
+cat /dev/null <<EOF
+------------------------------------------------------------------------
+End of functions from https://github.com/client9/shlib
+------------------------------------------------------------------------
+EOF
+
+help() {
+  cat <<EOF
+Usage: $0
+
+Install:
+  $0
+
+Install to <path/to/dir>:
+  BIN_DIR=<path/to/dir> $0
+
+Install specified version <vX.Y.Z>:
+  DAGGER_VERSION=<vX.Y.Z> $0
+
+Install latest dev build:
+  DAGGER_COMMIT=head $0
+Install specified dev build <commit sha>:
+  DAGGER_COMMIT=<commit sha> $0
+EOF
+}
+
+fetch_version() {
+  # attempt to interpret the DAGGER_VERSION as a build pointer, otherwise
+  # just use it's value directly
+  curl -sfL "${base}/${name}/versions/${DAGGER_VERSION}" || echo "${DAGGER_VERSION}"
+}
+
+base_url() {
+  os="$(uname_os)"
+  arch="$(uname_arch)"
+  if [ -n "$DAGGER_COMMIT" ]; then
+    path="main/${DAGGER_COMMIT}"
+  elif [ -n "$DAGGER_VERSION" ] && [ "$DAGGER_VERSION" != "latest" ]; then
+    path="releases/$(fetch_version)"
+  else
+    DAGGER_VERSION="latest"
+    path="releases/$(fetch_version)"
+  fi
+  url="${base}/${name}/${path}"
+  echo "$url"
+}
+
+tarball() {
+  os="$(uname_os)"
+  arch="$(uname_arch)"
+  if [ -n "$DAGGER_COMMIT" ]; then
+    version="${DAGGER_COMMIT}"
+  elif [ -n "$DAGGER_VERSION" ] && [ "$DAGGER_VERSION" != "latest" ]; then
+    version="v$(fetch_version)"
+  else
+    DAGGER_VERSION="latest"
+    version="v$(fetch_version)"
+  fi
+  name="${name}_${version}_${os}_${arch}"
+  if [ "$os" = "windows" ]; then
+    name="${name}.zip"
+  else
+    name="${name}.tar.gz"
+  fi
+  echo "$name"
+}
+
+install_shell_completion() {
+  # don't prompt shell completion installations in CI
+  if [ -n "$CI" ]; then
+    # GitHub Actions, Travis CI, CircleCI, Cirrus CI, GitLab CI, AppVeyor, CodeShip, dsari
+    return 0
+  fi
+  if [ -n "$BUILD_NUMBER" ]; then
+    # Jenkins, TeamCity
+    return 0
+  fi
+  if [ -n "$RUN_ID" ]; then
+    # TaskCluster, dsari
+    return 0
+  fi
+
+  echo "
+${binexe} has built-in shell completion. This is how you can install it for:
+
+  BASH:
+
+    1. Ensure that you install bash-completion using your package manager.
+
+    2. Add dagger completion to your personal bash completions dir
+
+      mkdir -p ${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions
+      ${binexe} completion bash > ${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions/dagger
+
+  ZSH:
+
+    1. Generate a _dagger completion script and write it to a file within your \$FPATH, e.g.:
+
+      ${binexe} completion zsh > /usr/local/share/zsh/site-functions/_dagger
+
+    2. Ensure that the following is present in your ~/.zshrc:
+
+      autoload -U compinit
+      compinit -i
+
+    zsh version 5.7 or later is recommended.
+
+  FISH:
+
+    1. Generate a dagger.fish completion script and write it to a file within fish completions, e.g.:
+
+      ${binexe} completion fish > ~/.config/fish/completions/dagger.fish
+  "
+}
+
+clean_install_version() {
+  DAGGER_VERSION=$(echo "$DAGGER_VERSION" | sed -E 's/^v+//g')
+}
+
+execute() {
+  clean_install_version
+  base_url="$(base_url)"
+  tarball="$(tarball)"
+  tarball_url="${base_url}/${tarball}"
+  checksum="checksums.txt"
+  checksum_url="${base_url}/${checksum}"
+  bin_dir="${BIN_DIR:-./bin}"
+  binexe="dagger"
+
+  tmpdir=$(mktemp -d)
+  log_debug "downloading files into ${tmpdir}"
+  http_download "${tmpdir}/${tarball}" "${tarball_url}"
+  http_download "${tmpdir}/${checksum}" "${checksum_url}"
+  hash_sha256_verify "${tmpdir}/${tarball}" "${tmpdir}/${checksum}"
+  srcdir="${tmpdir}"
+  (cd "${tmpdir}" && untar "${tarball}")
+  test ! -d "${bin_dir}" && install -d "${bin_dir}"
+  install "${srcdir}/${binexe}" "${bin_dir}"
+  log_debug "display shell completion instructions"
+  install_shell_completion
+  log_info "installed ${bin_dir}/${binexe}"
+  rm -rf "${tmpdir}"
+}
+
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+  help
+else
+  execute
+fi

--- a/src/dagger/install.sh
+++ b/src/dagger/install.sh
@@ -40,16 +40,7 @@ check_packages() {
 apt_get_update
 check_packages wget coreutils ca-certificates
 
-mkdir /tmp/dagger
-cd /tmp/dagger
-
-#wget -c "https://github.com/dagger/dagger/releases/download/$VERSION/dagger_${VERSION}_linux_${ARCHITECTURE}.tar.gz"  -O - | tar --directory "$LOCATION" -xz dagger
-wget -O /tmp/dagger/dagger_${VERSION}_linux_${ARCHITECTURE}.tar.gz "https://github.com/dagger/dagger/releases/download/$VERSION/dagger_${VERSION}_linux_${ARCHITECTURE}.tar.gz"
-wget -O /tmp/dagger/checksums.txt "https://github.com/dagger/dagger/releases/download/$VERSION/checksums.txt"
-
-sha256sum -c checksums.txt --ignore-missing || (echo "Checksum failed. Exiting." && exit 1)
-
-tar --directory "$LOCATION" -xzf "/tmp/dagger/dagger_${VERSION}_linux_${ARCHITECTURE}.tar.gz" dagger
+BIN_DIR="$LOCATION" ${PWD}/scripts/install-dagger.sh
 
 chmod +x "$LOCATION/dagger"
 
@@ -77,4 +68,4 @@ if [ "$COMPLETION" = "true" ]; then
 fi
 
 # Clean up
-rm -rf /var/lib/apt/lists/* /tmp/dagger
+rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Changes

- Add `install-dagger.sh` script based on official Dagger installer from https://dl.dagger.io
- Refactor `install.sh` to use new `install-dagger.sh` script instead of manual download/extraction
- Update Atuin's bash-preexec.sh from v0.5.0 to v0.6.0
- Simplify Atuin install script to use official installer
- Add Fish shell support for Atuin
- Fix various formatting and compatibility issues

## Benefits

- Improves reliability by using official installation methods
- Reduces custom download/verification logic
- Updates dependencies to their latest versions
- Better shell compatibility (adds Fish support)

## Testing

This refactoring maintains the same functionality while improving maintainability and reliability of the installation process.